### PR TITLE
Fix imports when using Swift modules

### DIFF
--- a/ios/RNTestFlight.h
+++ b/ios/RNTestFlight.h
@@ -1,8 +1,4 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNTestFlight : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
When a project is using Swift modules (like Expo 44+), then imports must use the `React/<header>.h` form, otherwise you get a compiler error: `duplicate interface definition for class 'RCTBridgeModule'`

This change should be compatible with React 40+, which introduced the `React/` headers.

See https://github.com/expo/expo/issues/15622#issuecomment-997225774 for the detailed investigation and fix.

I tested this in my project and it fixes the compilation.